### PR TITLE
style: change multiplication and division symbols

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,13 +19,13 @@
 	}
 
 	async function getEquation() {
-		const equation = consoleValue;
+		const equation = consoleValue.replace(/×/g, '*').replace(/÷/g, '/');
 
 		if (consoleValue === '') {
 			return false;
 		}
 
-		if (!/^(\d*\.?\d*)([+\-*/](\d*\.?\d*))*$/.test(consoleValue)) {
+		if (!/^(\d*\.?\d*)([+\-*/](\d*\.?\d*))*$/.test(equation)) {
 			answer = 'Syntax Error';
 			return;
 		}
@@ -86,14 +86,14 @@
 			</button>
 			<button
 				on:click={() => {
-					setCharacters('*');
+					setCharacters('×');
 				}}
 			>
 				&times;
 			</button>
 			<button
 				on:click={() => {
-					setCharacters('/');
+					setCharacters('÷');
 				}}
 			>
 				&divide;


### PR DESCRIPTION
## Description

- Changed the operation symbols shown in the console for multiplication and division

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/b6bfb427-ae76-41a6-8284-5596b13c273b)

After:
![image](https://github.com/user-attachments/assets/01267bc2-ddb3-472b-987c-607fadef3e9a)


